### PR TITLE
Min image size

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -9,7 +9,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   git \
-  build-essential \
+  gcc \
+  make \
   texlive \
   texlive-fonts-extra \
   texlive-lang-all \
@@ -38,6 +39,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   mkdir /opt/ploticus && \
   mv ../prefabs /opt/ploticus/. && \
   rm -rf ~/build && \
-  apt-get purge -y --auto-remove curl git build-essential
+  apt-get purge -y --auto-remove curl git gcc make
 
 CMD tail -f /dev/null

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -7,13 +7,18 @@ COPY ploticus_makefile /root/build/.
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
   git \
   gcc \
   make \
   texlive \
   texlive-fonts-extra \
-  texlive-lang-all \
+  texlive-lang-english \
+  texlive-lang-european \
+  texlive-lang-french \
+  texlive-lang-german \
+  texlive-lang-spanish \
+  ca-certificates \
   pcregrep \
   ploticus \
   mysql-client \
@@ -39,6 +44,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   mkdir /opt/ploticus && \
   mv ../prefabs /opt/ploticus/. && \
   rm -rf ~/build && \
-  apt-get purge -y --auto-remove curl git gcc make
+  rm -rf /var/lib/apt/lists/* && \
+  apt-get purge -y --auto-remove curl git gcc make && apt-get autoclean && apt-get autoremove
 
 CMD tail -f /dev/null

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN mkdir build
+RUN mkdir ~/build
 
 COPY ploticus_makefile build/.
 
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
   mv pl /usr/local/bin/. && \
   mkdir /opt/ploticus && \
   mv ../prefabs /opt/ploticus/. && \
-  rm -rf build && \
+  rm -rf ~/build && \
   apt-get purge -y --auto-remove wget git gcc make build-essential
 
 CMD tail -f /dev/null

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -4,6 +4,8 @@ RUN mkdir build
 
 COPY ploticus_makefile build/.
 
+ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
+
 RUN apt-get update && apt-get upgrade && apt-get install -y \
   git \
   build-essential \
@@ -21,8 +23,8 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
   libpng-dev \
   zlib1g-dev \
   libfreetype* \
-  php7.0 \
-	php7.0-mysqli && \
+  php7.2 \
+	php7.2-mysql && \
   git clone https://github.com/espena/mkres.git && \
   cd mkres && \
   make install && \
@@ -35,8 +37,6 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
   mkdir /opt/ploticus && \
   mv ../prefabs /opt/ploticus/. && \
   rm -rf build && \
-  apt-get purge -y --auto-remove wget git gcc make build-essential && \
-
-ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
+  apt-get purge -y --auto-remove wget git gcc make build-essential
 
 CMD tail -f /dev/null

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
-RUN mkdir ~/build
+RUN mkdir build
 
-COPY ploticus_makefile ~/build/.
+COPY ploticus_makefile /root/build/.
 
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 ENV DEBIAN_FRONTEND=noninteractive

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:latest
 
 RUN mkdir ~/build
 

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -38,6 +38,6 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
   mkdir /opt/ploticus && \
   mv ../prefabs /opt/ploticus/. && \
   rm -rf ~/build && \
-  apt-get purge -y --auto-remove wget git gcc make build-essential
+  apt-get purge -y --auto-remove curl git build-essential
 
 CMD tail -f /dev/null

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir build
 COPY ploticus_makefile build/.
 
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get upgrade && apt-get install -y \
   git \

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 RUN mkdir ~/build
 
-COPY ploticus_makefile build/.
+COPY ploticus_makefile ~/build/.
 
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
   cd ~/build && \
   curl -L https://sourceforge.net/projects/ploticus/files/latest/download?source=files | tar xvz && \
   cd ~/build/ploticus*/src && \
-  cp -f ../../ploticus_makefile Makefile && \
+  cp -f ~/build/ploticus_makefile Makefile && \
   make && \
   mv pl /usr/local/bin/. && \
   mkdir /opt/ploticus && \

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -29,9 +29,9 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
   git clone https://github.com/espena/mkres.git && \
   cd mkres && \
   make install && \
-  cd build && \
+  cd ~/build && \
   curl -L https://sourceforge.net/projects/ploticus/files/latest/download?source=files | tar xvz && \
-  cd build/ploticus*/src && \
+  cd ~/build/ploticus*/src && \
   cp -f ../../ploticus_makefile Makefile && \
   make && \
   mv pl /usr/local/bin/. && \

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -7,7 +7,7 @@ COPY ploticus_makefile /root/build/.
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN apt-get update && apt-get upgrade && apt-get install -y \
   git \
   build-essential \
   texlive \

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y \
+RUN mkdir build
+
+COPY ploticus_makefile build/.
+
+RUN apt-get update && apt-get upgrade && apt-get install -y \
   git \
   build-essential \
   texlive \
@@ -18,26 +22,20 @@ RUN apt-get update && apt-get install -y \
   zlib1g-dev \
   libfreetype* \
   php7.0 \
-	php7.0-mysqli
-
-RUN git clone https://github.com/espena/mkres.git && \
+	php7.0-mysqli && \
+  git clone https://github.com/espena/mkres.git && \
   cd mkres && \
-  make install
-
-RUN mkdir build && \
-    cd build && \
-    curl -L https://sourceforge.net/projects/ploticus/files/latest/download?source=files | tar xvz
-
-COPY ploticus_makefile build/.
-
-RUN cd build/ploticus*/src && \
-    cp -f ../../ploticus_makefile Makefile && \
-    make && \
-    mv pl /usr/local/bin/. && \
-    mkdir /opt/ploticus && \
-    mv ../prefabs /opt/ploticus/.
-
-RUN rm -rf build
+  make install && \
+  cd build && \
+  curl -L https://sourceforge.net/projects/ploticus/files/latest/download?source=files | tar xvz && \
+  cd build/ploticus*/src && \
+  cp -f ../../ploticus_makefile Makefile && \
+  make && \
+  mv pl /usr/local/bin/. && \
+  mkdir /opt/ploticus && \
+  mv ../prefabs /opt/ploticus/. && \
+  rm -rf build && \
+  apt-get purge -y --auto-remove wget git gcc make build-essential && \
 
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 RUN mkdir ~/build
 
-COPY ploticus_makefile ~/build/.
+COPY ploticus_makefile /root/build/.
 
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 ENV DEBIAN_FRONTEND=noninteractive

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update && apt-get upgrade && apt-get install -y \
   libpng-dev \
   zlib1g-dev \
   libfreetype* \
-  php7.2 \
-	php7.2-mysql && \
+  php7.0 \
+	php7.0-mysqli && \
   git clone https://github.com/espena/mkres.git && \
   cd mkres && \
   make install && \

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
-RUN mkdir build
+RUN mkdir ~/build
 
-COPY ploticus_makefile /root/build/.
+COPY ploticus_makefile ~/build/.
 
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 ENV DEBIAN_FRONTEND=noninteractive

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 
 RUN mkdir ~/build
 

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   libpng-dev \
   zlib1g-dev \
   libfreetype* \
-  php7.0 \
-	php7.0-mysqli && \
+  php7.2 \
+	php7.2-mysql && \
   git clone https://github.com/espena/mkres.git && \
   cd mkres && \
   make install && \

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -7,7 +7,7 @@ COPY ploticus_makefile /root/build/.
 ENV PLOTICUS_PREFABS=/opt/ploticus/prefabs
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   git \
   build-essential \
   texlive \


### PR DESCRIPTION
Rewrote the Dockerfile to minimize image size.

Main changes:

- building and compiling, then removing build tools in same RUN
- removing apt-lists after building
- reducing number of languages from all to: english, german, french, spanish and other european languages

Test it and see if it works. Looks to be about 1GB smaller or so.